### PR TITLE
goodix_driver_gt9886: Add gaming mode support for custom roms.

### DIFF
--- a/drivers/input/touchscreen/goodix_driver_gt9886/goodix_ts_core.c
+++ b/drivers/input/touchscreen/goodix_driver_gt9886/goodix_ts_core.c
@@ -632,6 +632,46 @@ static ssize_t goodix_ts_irq_info_store(struct device *dev,
 	return count;
 }
 
+static struct xiaomi_touch_interface xiaomi_touch_interfaces;
+
+static ssize_t goodix_ts_game_mode_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct goodix_ts_core *core_data = dev_get_drvdata(dev);
+
+	if(core_data == NULL)
+	  return snprintf(buf, PAGE_SIZE, "error\n");
+
+        return snprintf(buf, PAGE_SIZE, "%d %d %d %d\n",
+			xiaomi_touch_interfaces.touch_mode[Touch_Game_Mode][GET_CUR_VALUE],
+			xiaomi_touch_interfaces.touch_mode[Touch_Tolerance][GET_CUR_VALUE],
+			xiaomi_touch_interfaces.touch_mode[Touch_UP_THRESHOLD][GET_CUR_VALUE],
+			xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][GET_CUR_VALUE]);
+}
+
+static ssize_t goodix_ts_game_mode_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	int rc, i;
+	unsigned u[Touch_Mode_NUM] = { 0 };
+
+	ts_info("GAME -> buf : %s, len : %d\n", buf, count);
+
+	rc = sscanf(buf, "%d %d %d %d\n", &u[Touch_Game_Mode], &u[Touch_Tolerance], &u[Touch_UP_THRESHOLD], &u[Touch_Edge_Filter]);
+
+	if (rc != 4) {
+		ts_info("GAME -> Invalid Format!");
+		return -EINVAL;
+	}
+
+	for (i = 0; i < Touch_Mode_NUM; i++) {
+		// gtp_set_cur_value(i, u[i]);
+		xiaomi_touch_interfaces.setModeValue(i, u[i]);
+	}
+
+    return count;
+}
+
 static DEVICE_ATTR(extmod_info, S_IRUGO, goodix_ts_extmod_show, NULL);
 static DEVICE_ATTR(driver_info, S_IRUGO, goodix_ts_driver_info_show, NULL);
 static DEVICE_ATTR(chip_info, S_IRUGO, goodix_ts_chip_info_show, NULL);
@@ -641,6 +681,8 @@ static DEVICE_ATTR(send_cfg, S_IWUSR | S_IWGRP, NULL, goodix_ts_send_cfg_store);
 static DEVICE_ATTR(read_cfg, S_IRUGO, goodix_ts_read_cfg_show, NULL);
 static DEVICE_ATTR(irq_info, S_IRUGO | S_IWUSR | S_IWGRP,
 		goodix_ts_irq_info_show, goodix_ts_irq_info_store);
+static DEVICE_ATTR(game_mode, S_IRUGO | S_IWUSR | S_IWGRP,
+		goodix_ts_game_mode_show, goodix_ts_game_mode_store);
 
 static struct attribute *sysfs_attrs[] = {
 	&dev_attr_extmod_info.attr,
@@ -651,6 +693,7 @@ static struct attribute *sysfs_attrs[] = {
 	&dev_attr_send_cfg.attr,
 	&dev_attr_read_cfg.attr,
 	&dev_attr_irq_info.attr,
+	&dev_attr_game_mode.attr,
 	NULL,
 };
 
@@ -2082,7 +2125,6 @@ static int gtp_power_supply_event(struct notifier_block *nb, unsigned long event
 }
 
 #ifdef CONFIG_TOUCHSCREEN_XIAOMI_TOUCHFEATURE
-static struct xiaomi_touch_interface xiaomi_touch_interfaces;
 
 static int gtp_set_cur_value(int gtp_mode, int gtp_value)
 {
@@ -2114,7 +2156,11 @@ static int gtp_set_cur_value(int gtp_mode, int gtp_value)
 	if (gtp_mode >= Touch_Mode_NUM && gtp_mode < 0) {
 		ts_err("gtp mode is error:%d", gtp_mode);
 		return -EINVAL;
-	} else if (xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE] >
+	}
+
+	xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE] = gtp_value;
+
+	if (xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE] >
 			xiaomi_touch_interfaces.touch_mode[gtp_mode][GET_MAX_VALUE]) {
 
 		xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE] =
@@ -2127,9 +2173,7 @@ static int gtp_set_cur_value(int gtp_mode, int gtp_value)
 				xiaomi_touch_interfaces.touch_mode[gtp_mode][GET_MIN_VALUE];
 	}
 
-	xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE] = gtp_value;
-
-	if (gtp_mode == Touch_Game_Mode && gtp_value == 0) {
+	if (xiaomi_touch_interfaces.touch_mode[Touch_Game_Mode][SET_CUR_VALUE] == 0) {
 		ts_info("exit touch game mode");
 		state_data[0] = GTP_EXIT_GAME_CMD;
 		state_data[1] = 0x00;
@@ -2139,68 +2183,72 @@ static int gtp_set_cur_value(int gtp_mode, int gtp_value)
 			ts_err("exit game mode fail");
 		}
 		goodix_game_value = 0;
+		xiaomi_touch_interfaces.touch_mode[gtp_mode][GET_CUR_VALUE] = xiaomi_touch_interfaces.touch_mode[gtp_mode][GET_DEF_VALUE];
+		return ret;
+
+	} else {
+
+		xiaomi_touch_interfaces.touch_mode[Touch_Panel_Orientation][SET_CUR_VALUE] = 1; //Temp Workaround
+
+		for (i = 0; i < Touch_Mode_NUM; i++) {
+			switch (i) {
+			case Touch_Game_Mode:
+					break;
+			case Touch_UP_THRESHOLD:
+					temp_value =
+					xiaomi_touch_interfaces.touch_mode[Touch_UP_THRESHOLD][SET_CUR_VALUE];
+					goodix_game_value &= 0xFC;
+					goodix_game_value |= temp_value;
+					break;
+			case Touch_Tolerance:
+					temp_value =
+					xiaomi_touch_interfaces.touch_mode[Touch_Tolerance][SET_CUR_VALUE];
+					temp_value = 3 - temp_value;
+					goodix_game_value &= 0xF3;
+					goodix_game_value |= (temp_value << 2);
+					break;
+			case Touch_Edge_Filter:
+					temp_value =
+					xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][SET_CUR_VALUE];
+					goodix_game_value &= 0xCF;
+					goodix_game_value |= (temp_value << 4);
+					break;
+			case Touch_Panel_Orientation:
+					/* 0,1,2,3 = 0, 90, 180,270 */
+					temp_value =
+					xiaomi_touch_interfaces.touch_mode[Touch_Panel_Orientation][SET_CUR_VALUE];
+					if (temp_value == 3)
+						temp_value = 2;
+					else if (temp_value == 2)
+						temp_value = 3;
+					goodix_game_value &= 0x3F;
+					goodix_game_value |= (temp_value << 6);
+					break;
+			default:
+					/* Don't support */
+					break;
+
+			};
+		}
+
+		xiaomi_touch_interfaces.touch_mode[gtp_mode][GET_CUR_VALUE] =
+						xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE];
+
+		if (xiaomi_touch_interfaces.touch_mode[Touch_Game_Mode][SET_CUR_VALUE]) {
+			state_data[0] = GTP_GAME_CMD;
+			state_data[1] = goodix_game_value;
+			state_data[2] = 0xFF & (0 - state_data[0] - state_data[1]);
+
+			ts_info("GAME -> MODE:%d, VALUE:%d --> cmd1:0x%x, cmd2:0x%x, cmd3:0x%x", gtp_mode, gtp_value, state_data[0], state_data[1], state_data[2]);
+
+			ret = goodix_i2c_write(dev, GTP_GAME_CMD_ADD, state_data, 3);
+
+			if (ret < 0) {
+				ts_err("change game mode fail");
+			}
+		}
 		return ret;
 	}
-
-	for (i = 0; i < Touch_Mode_NUM; i++) {
-		switch (i) {
-		case Touch_Game_Mode:
-				break;
-		case Touch_Active_MODE:
-				break;
-		case Touch_UP_THRESHOLD:
-				temp_value =
-				xiaomi_touch_interfaces.touch_mode[Touch_UP_THRESHOLD][SET_CUR_VALUE];
-				goodix_game_value &= 0xFC;
-				goodix_game_value |= temp_value;
-				break;
-		case Touch_Tolerance:
-				temp_value =
-				xiaomi_touch_interfaces.touch_mode[Touch_Tolerance][SET_CUR_VALUE];
-				temp_value = 3 - temp_value;
-				goodix_game_value &= 0xF3;
-				goodix_game_value |= (temp_value << 2);
-				break;
-		case Touch_Edge_Filter:
-				temp_value =
-				xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][SET_CUR_VALUE];
-				goodix_game_value &= 0xCF;
-				goodix_game_value |= (temp_value << 4);
-				break;
-		case Touch_Panel_Orientation:
-				/* 0,1,2,3 = 0, 90, 180,270 */
-				temp_value =
-				xiaomi_touch_interfaces.touch_mode[Touch_Panel_Orientation][SET_CUR_VALUE];
-				if (temp_value == 3)
-					temp_value = 2;
-				else if (temp_value == 2)
-					temp_value = 3;
-				goodix_game_value &= 0x3F;
-				goodix_game_value |= (temp_value << 6);
-				break;
-		default:
-				/* Don't support */
-				break;
-
-		};
-	}
-	ts_info("mode:%d, value:%d, write value:0x%x", gtp_mode, gtp_value, goodix_game_value);
-
-	xiaomi_touch_interfaces.touch_mode[gtp_mode][GET_CUR_VALUE] =
-					xiaomi_touch_interfaces.touch_mode[gtp_mode][SET_CUR_VALUE];
-
-	if (xiaomi_touch_interfaces.touch_mode[Touch_Game_Mode][SET_CUR_VALUE]) {
-		state_data[0] = GTP_GAME_CMD;
-		state_data[1] = goodix_game_value;
-		state_data[2] = 0xFF & (0 - state_data[0] - state_data[1]);
-
-		ret = goodix_i2c_write(dev, GTP_GAME_CMD_ADD, state_data, 3);
-
-		if (ret < 0) {
-			ts_err("change game mode fail");
-		}
-	}
-	return ret;
 }
 
 static int gtp_get_mode_value(int mode, int value_type)
@@ -2265,11 +2313,11 @@ static void gtp_init_touchmode_data(void)
 	xiaomi_touch_interfaces.touch_mode[Touch_Game_Mode][GET_CUR_VALUE] = 0;
 
 	/* Acitve Mode */
-	xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_MAX_VALUE] = 1;
-	xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_MIN_VALUE] = 0;
-	xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_DEF_VALUE] = 0;
-	xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][SET_CUR_VALUE] = 0;
-	xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_CUR_VALUE] = 0;
+	// xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_MAX_VALUE] = 1;
+	// xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_MIN_VALUE] = 0;
+	// xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_DEF_VALUE] = 0;
+	// xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][SET_CUR_VALUE] = 0;
+	// xiaomi_touch_interfaces.touch_mode[Touch_Active_MODE][GET_CUR_VALUE] = 0;
 
 	/* finger hysteresis */
 	xiaomi_touch_interfaces.touch_mode[Touch_UP_THRESHOLD][GET_MAX_VALUE] = 3;
@@ -2287,7 +2335,7 @@ static void gtp_init_touchmode_data(void)
 
 	/*	edge filter */
 	xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][GET_MAX_VALUE] = 3;
-	xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][GET_MIN_VALUE] = 1;
+	xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][GET_MIN_VALUE] = 0;
 	xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][GET_DEF_VALUE] = 1;
 	xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][SET_CUR_VALUE] = 1;
 	xiaomi_touch_interfaces.touch_mode[Touch_Edge_Filter][GET_CUR_VALUE] = 1;
@@ -2300,7 +2348,7 @@ static void gtp_init_touchmode_data(void)
 	xiaomi_touch_interfaces.touch_mode[Touch_Panel_Orientation][GET_CUR_VALUE] = 0;
 
 	for (i = 0; i < Touch_Mode_NUM; i++) {
-		ts_info("mode:%d, set cur:%d, get cur:%d, def:%d min:%d max:%d\n",
+		ts_info("GAME --> mode:%d, set cur:%d, get cur:%d, def:%d, min:%d, max:%d\n",
 			i,
 			xiaomi_touch_interfaces.touch_mode[i][SET_CUR_VALUE],
 			xiaomi_touch_interfaces.touch_mode[i][GET_CUR_VALUE],

--- a/drivers/input/touchscreen/xiaomi/xiaomi_touch.h
+++ b/drivers/input/touchscreen/xiaomi/xiaomi_touch.h
@@ -36,18 +36,11 @@ enum MODE_CMD {
 
 enum  MODE_TYPE {
 	Touch_Game_Mode        = 0,
-	Touch_Active_MODE      = 1,
+	Touch_Tolerance        = 1,
 	Touch_UP_THRESHOLD     = 2,
-	Touch_Tolerance        = 3,
-	Touch_Wgh_Min          = 4,
-	Touch_Wgh_Max          = 5,
-	Touch_Wgh_Step         = 6,
-	Touch_Edge_Filter      = 7,
-	Touch_Panel_Orientation = 8,
-	Touch_Report_Rate      = 9,
-	Touch_Fod_Enable       = 10,
-	Touch_Aod_Enable       = 11,
-	Touch_Mode_NUM         = 12,
+	Touch_Edge_Filter      = 3,
+	Touch_Panel_Orientation = 4,
+	Touch_Mode_NUM         = 5,
 };
 
 struct xiaomi_touch_interface {


### PR DESCRIPTION
I have tried to add stock MIUI gaming features to custom roms. I checked it and works pretty well. I hope it might be a necessary feature for userpace to communicate. It also increases report rate to 180Hz when gaming mode is enabled. 